### PR TITLE
Include orbit module

### DIFF
--- a/orbit/pom.xml
+++ b/orbit/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.orbit.com.jcraft</groupId>
+    <artifactId>jsch</artifactId>
+    <version>0.1.55-wso2v2-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>JSch Orbit</name>
+    <description>
+        A pure Java implementation of SSH2
+    </description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            com.jcraft.jsch.*;version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            !com.jcraft.jsch.*,
+                            com.jcraft.jzlib;resolution:=optional,
+                            javax.crypto;resolution:=optional,
+                            javax.crypto.interfaces;resolution:=optional,
+                            javax.crypto.spec;resolution:=optional,
+                            org.ietf.jgss;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.wso2.com.jcraft</groupId>
   <artifactId>jsch</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
   <version>0.1.55-wso2v2-SNAPSHOT</version>
   <name>JSch</name>
   <url>http://www.jcraft.com/jsch/</url>
@@ -95,4 +95,8 @@
       </extension>
     </extensions>
   </build>
+
+  <modules>
+    <module>orbit</module>
+  </modules>
 </project>


### PR DESCRIPTION
## Purpose
We will deprecate the https://github.com/wso2/orbit/tree/master/jsch and will maintain the orbit bundle from here for future improvements.